### PR TITLE
Issue #3: Node.js - Create Global Table operations code examples using the AWS Node.js SDK

### DIFF
--- a/node.js/WorkingWithTables/add-global-table-region.js
+++ b/node.js/WorkingWithTables/add-global-table-region.js
@@ -1,0 +1,25 @@
+const AWS = require("aws-sdk");
+
+const dynamodb = new AWS.DynamoDB({ region: "us-west-2" });
+
+const tableName = "Music";
+
+async function addGlobalTableRegion() {
+  const params = {
+    TableName: tableName,
+    ReplicaUpdates: [
+      {
+        Create: {
+          RegionName: "ap-northeast-2",
+        },
+      },
+    ],
+  };
+
+  const response = await dynamodb.updateTable(params).promise();
+  return response;
+}
+
+addGlobalTableRegion()
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch((error) => console.error(JSON.stringify(error, null, 2)));

--- a/node.js/WorkingWithTables/create-global-table.js
+++ b/node.js/WorkingWithTables/create-global-table.js
@@ -1,0 +1,24 @@
+const AWS = require("aws-sdk");
+
+const dynamodb = new AWS.DynamoDB({ region: "us-west-2" });
+
+const tableName = "Music";
+
+// Note: This method only applies to Version 2017.11.29 of global tables.
+// Before using this method, you must create the table in both regions.
+async function createGlobalTable() {
+  const params = {
+    GlobalTableName: tableName,
+    ReplicationGroup: [
+      { RegionName: "us-west-2" },
+      { RegionName: "ap-northeast-2" },
+    ],
+  };
+
+  const response = await dynamodb.createGlobalTable(params).promise();
+  return response;
+}
+
+createGlobalTable()
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch((error) => console.error(JSON.stringify(error, null, 2)));

--- a/node.js/WorkingWithTables/delete-global-table-region.js
+++ b/node.js/WorkingWithTables/delete-global-table-region.js
@@ -1,0 +1,25 @@
+const AWS = require("aws-sdk");
+
+const dynamodb = new AWS.DynamoDB({ region: "us-west-2" });
+
+const tableName = "Music";
+
+async function deleteGlobalTableRegion() {
+  const params = {
+    TableName: tableName,
+    ReplicaUpdates: [
+      {
+        Delete: {
+          RegionName: "ap-northeast-2",
+        },
+      },
+    ],
+  };
+
+  const response = await dynamodb.updateTable(params).promise();
+  return response;
+}
+
+deleteGlobalTableRegion()
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch((error) => console.error(JSON.stringify(error, null, 2)));

--- a/node.js/WorkingWithTables/describe-global-table-and-global-table-settings.js
+++ b/node.js/WorkingWithTables/describe-global-table-and-global-table-settings.js
@@ -1,0 +1,35 @@
+const AWS = require("aws-sdk");
+
+const dynamodb = new AWS.DynamoDB({ region: "us-west-2" });
+
+const tableName = "Music";
+
+// Note: This method only applies to Version 2017.11.29 of global tables.
+async function describeGlobalTable() {
+  const params = {
+    GlobalTableName: tableName,
+  };
+
+  const response = await dynamodb.describeGlobalTable(params).promise();
+  return response;
+}
+
+// Note: This method only applies to Version 2017.11.29 of global tables.
+async function describeGlobalTableSettings() {
+  const params = {
+    GlobalTableName: tableName,
+  };
+
+  const response = await dynamodb.describeGlobalTableSettings(params).promise();
+  return response;
+}
+
+async function describeAll() {
+  const information = await describeGlobalTable();
+  console.log(JSON.stringify(information, null, 2));
+
+  const settings = await describeGlobalTableSettings();
+  console.log(JSON.stringify(settings, null, 2));
+}
+
+describeAll().catch((error) => console.error(JSON.stringify(error, null, 2)));

--- a/node.js/WorkingWithTables/update-global-table-and-global-table-settings.js
+++ b/node.js/WorkingWithTables/update-global-table-and-global-table-settings.js
@@ -1,0 +1,39 @@
+const AWS = require("aws-sdk");
+
+const dynamodb = new AWS.DynamoDB({ region: "us-west-2" });
+
+const tableName = "Music";
+
+// Before using this method, you must create the table in the region.
+async function updateGlobalTable() {
+  const params = {
+    GlobalTableName: tableName,
+    ReplicaUpdates: [
+      {
+        Create: {
+          RegionName: "us-east-1",
+        },
+      },
+    ],
+  };
+
+  const response = await dynamodb.updateGlobalTable(params).promise();
+  return response;
+}
+
+async function updateGlobalTableSettings() {
+  const params = {
+    GlobalTableName: tableName,
+    GlobalTableProvisionedWriteCapacityUnits: "10",
+  };
+
+  const response = await dynamodb.updateGlobalTableSettings(params).promise();
+  return response;
+}
+
+async function updateAll() {
+  await updateGlobalTable();
+  await updateGlobalTableSettings();
+}
+
+updateAll().catch((error) => console.error(JSON.stringify(error, null, 2)));


### PR DESCRIPTION
Some methods only apply to Version 2017.11.29 of global tables.
I mentioned it in the code.