### PR TITLE
Added examples queries using pagination

### DIFF
--- a/node.js/WorkingWithQueries/query-with-pagination-all-data.js
+++ b/node.js/WorkingWithQueries/query-with-pagination-all-data.js
@@ -2,9 +2,9 @@
  * This example uses an extended version of the ProductCatalog data set
  * https://gist.github.com/jprivillaso/7063b5e082ed2f553b697d40c60c473e
  */
-const AWS = require('aws-sdk');
+const AWS = require("aws-sdk");
 
-AWS.config.update({ region: 'us-west-2' });
+AWS.config.update({ region: "us-west-2" });
 
 const documentClient = new AWS.DynamoDB.DocumentClient();
 
@@ -17,19 +17,21 @@ async function* getDataIterator() {
    * query again until the LastEvaluatedKey returned is null
    */
   const params = {
-    TableName: 'Thread',
-    KeyConditionExpression: '#forumName = :forumName',
+    TableName: "Thread",
+    KeyConditionExpression: "#forumName = :forumName",
     ExpressionAttributeNames: {
-      '#forumName': 'ForumName',
+      "#forumName": "ForumName",
     },
     ExpressionAttributeValues: {
-      ':forumName': "Amazon DynamoDB",
+      ":forumName": "Amazon DynamoDB",
     },
-    ScanIndexForward: true // Default value is true
+    ScanIndexForward: true, // Default value is true
   };
 
   while (!done) {
-    const { Items, LastEvaluatedKey } = await documentClient.query(params).promise();
+    const { Items, LastEvaluatedKey } = await documentClient
+      .query(params)
+      .promise();
 
     if (!LastEvaluatedKey) {
       done = true;
@@ -47,27 +49,25 @@ const queryAllData = async () => {
   try {
     const allData = [];
 
-		for await (const dataBatch of getDataIterator()) {
+    for await (const dataBatch of getDataIterator()) {
       allData.push(...dataBatch);
     }
-
     return allData;
-	} catch (error) {
-		throw new Error(JSON.stringify(error, null, 2));
-	}
-}
+  } catch (error) {
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+};
 
 (async () => {
-	try {
+  try {
     /**
      * If you need to query all the data for any reason, you will need to continue
      * querying until the LastEvaluatedKey returned is null
      */
     const allData = await queryAllData();
-    console.log('Should contain all the data ---');
-    console.log('Query succeeded:', JSON.stringify(allData, null, 2));
-
-	} catch (error) {
-		console.error(error);
-	}
+    console.log("Should contain all the data ---");
+    console.log("Query succeeded:", JSON.stringify(allData, null, 2));
+  } catch (error) {
+    console.error(error);
+  }
 })();

--- a/node.js/WorkingWithQueries/query-with-pagination-all-data.js
+++ b/node.js/WorkingWithQueries/query-with-pagination-all-data.js
@@ -1,0 +1,73 @@
+/**
+ * This example uses an extended version of the ProductCatalog data set
+ * https://gist.github.com/jprivillaso/7063b5e082ed2f553b697d40c60c473e
+ */
+const AWS = require('aws-sdk');
+
+AWS.config.update({ region: 'us-west-2' });
+
+const documentClient = new AWS.DynamoDB.DocumentClient();
+
+async function* getDataIterator() {
+  let done = false;
+
+  /**
+   * In this example, the pageSize is not needed. If you have so much data,
+   * DynamoDB will return the LastEvaluatedKey and then you should continue
+   * query again until the LastEvaluatedKey returned is null
+   */
+  const params = {
+    TableName: 'Thread',
+    KeyConditionExpression: '#forumName = :forumName',
+    ExpressionAttributeNames: {
+      '#forumName': 'ForumName',
+    },
+    ExpressionAttributeValues: {
+      ':forumName': "Amazon DynamoDB",
+    },
+    ScanIndexForward: true // Default value is true
+  };
+
+  while (!done) {
+    const { Items, LastEvaluatedKey } = await documentClient.query(params).promise();
+
+    if (!LastEvaluatedKey) {
+      done = true;
+    } else {
+      params.ExclusiveStartKey = LastEvaluatedKey;
+    }
+
+    if (Items && Items.length > 0) {
+      yield Items;
+    }
+  }
+}
+
+const queryAllData = async () => {
+  try {
+    const allData = [];
+
+		for await (const dataBatch of getDataIterator()) {
+      allData.push(...dataBatch);
+    }
+
+    return allData;
+	} catch (error) {
+		throw new Error(JSON.stringify(error, null, 2));
+	}
+}
+
+(async () => {
+	try {
+    /**
+     * If you need to query all the data for any reason, you will need to continue
+     * querying until the LastEvaluatedKey returned is null
+     */
+    const allData = await queryAllData();
+    console.log('Should contain all the data ---');
+    console.log('Query succeeded:', JSON.stringify(allData, null, 2));
+
+	} catch (error) {
+		console.error(error);
+	}
+})();

--- a/node.js/WorkingWithQueries/query-with-pagination-backwards.js
+++ b/node.js/WorkingWithQueries/query-with-pagination-backwards.js
@@ -1,0 +1,96 @@
+/**
+ * This example uses an extended version of the ProductCatalog data set
+ * https://gist.github.com/jprivillaso/7063b5e082ed2f553b697d40c60c473e
+ */
+const AWS = require('aws-sdk');
+
+AWS.config.update({ region: 'us-west-2' });
+
+const documentClient = new AWS.DynamoDB.DocumentClient();
+
+const printLastEvalMessage = (lastEvaluatedKey) => {
+	const message = `
+    Not all items have been retrieved by this query.
+    At least one another request is required to get all available items.
+    The last evaluated key corresponds to:
+    ${JSON.stringify(lastEvaluatedKey)}.
+  `.replace(/\s+/gm, ' ');
+
+  console.log(message);
+}
+
+const queryPaginatedData = async (pageSize, lastKey, scanForward) => {
+	try {
+		const params = {
+      TableName: 'Thread',
+      KeyConditionExpression: '#forumName = :forumName',
+      ExpressionAttributeNames: {
+        '#forumName': 'ForumName',
+      },
+      ExpressionAttributeValues: {
+        ':forumName': "Amazon DynamoDB",
+      },
+      /**
+       * This represents the amount of records per page. It's not needed, but we'll use it to simulate
+       * the pagination
+       */
+      Limit: pageSize,
+      ScanIndexForward: scanForward // Default value is true
+    };
+
+    /**
+     * The ExclusiveStartKey marks where the next page should start.
+     * DynamoDB will return ${pageSize} items beyond this point
+     */
+    if (lastKey) params.ExclusiveStartKey = lastKey;
+
+		const response = await documentClient.query(params).promise();
+
+		if (response.LastEvaluatedKey) {
+      printLastEvalMessage(response.LastEvaluatedKey);
+		}
+
+		return response;
+	} catch (error) {
+		throw new Error(JSON.stringify(error, null, 2));
+	}
+};
+
+(async () => {
+	try {
+    console.log('---------------------Page 1---------------------');
+		const {
+      Items: dataPage1,
+      LastEvaluatedKey: lastKeyPage1
+    } = await queryPaginatedData(2, null, true);
+    console.log('Query succeeded Page 1:', JSON.stringify(dataPage1.map(d => d.Subject), null, 2));
+    console.log('Last Evaluated Key Page 1:', lastKeyPage1);
+
+    /**
+     * The example contains 8 items in the table. If you query the data with a page size 2,
+     * you'll need to continue querying the data
+     */
+    console.log('---------------------Page 2---------------------');
+    const {
+      Items: dataPage2,
+      LastEvaluatedKey: lastKeyPage2
+    } = await queryPaginatedData(2, lastKeyPage1, true);
+    console.log('Query succeeded Page 2:', JSON.stringify(dataPage2.map(d => d.Subject), null, 2));
+    console.log('Last Evaluated Key Page 2:', lastKeyPage2);
+
+    /**
+     * Now let's scan backwards. Be aware that scanning backwards is not inclusive. It
+     * will return all the possible data before the LastEvaluatedKey provided.
+     */
+    console.log('---------------------Backwards-------------------');
+    const {
+      Items: dataPage3,
+      LastEvaluatedKey: lastKeyPage3
+    } = await queryPaginatedData(2, lastKeyPage2, false);
+    console.log('Query succeeded Page 1:', JSON.stringify(dataPage3.map(d => d.Subject), null, 2));
+    console.log('Last Evaluated Key Page 1:', lastKeyPage3);
+
+	} catch (error) {
+		console.error(error);
+	}
+})();

--- a/node.js/WorkingWithQueries/query-with-pagination-backwards.js
+++ b/node.js/WorkingWithQueries/query-with-pagination-backwards.js
@@ -2,40 +2,40 @@
  * This example uses an extended version of the ProductCatalog data set
  * https://gist.github.com/jprivillaso/7063b5e082ed2f553b697d40c60c473e
  */
-const AWS = require('aws-sdk');
+const AWS = require("aws-sdk");
 
-AWS.config.update({ region: 'us-west-2' });
+AWS.config.update({ region: "us-west-2" });
 
 const documentClient = new AWS.DynamoDB.DocumentClient();
 
 const printLastEvalMessage = (lastEvaluatedKey) => {
-	const message = `
+  const message = `
     Not all items have been retrieved by this query.
     At least one another request is required to get all available items.
     The last evaluated key corresponds to:
     ${JSON.stringify(lastEvaluatedKey)}.
-  `.replace(/\s+/gm, ' ');
+  `.replace(/\s+/gm, " ");
 
   console.log(message);
-}
+};
 
 const queryPaginatedData = async (pageSize, lastKey, scanForward) => {
-	try {
-		const params = {
-      TableName: 'Thread',
-      KeyConditionExpression: '#forumName = :forumName',
+  try {
+    const params = {
+      TableName: "Thread",
+      KeyConditionExpression: "#forumName = :forumName",
       ExpressionAttributeNames: {
-        '#forumName': 'ForumName',
+        "#forumName": "ForumName",
       },
       ExpressionAttributeValues: {
-        ':forumName': "Amazon DynamoDB",
+        ":forumName": "Amazon DynamoDB",
       },
       /**
        * This represents the amount of records per page. It's not needed, but we'll use it to simulate
        * the pagination
        */
       Limit: pageSize,
-      ScanIndexForward: scanForward // Default value is true
+      ScanIndexForward: scanForward, // Default value is true
     };
 
     /**
@@ -44,53 +44,73 @@ const queryPaginatedData = async (pageSize, lastKey, scanForward) => {
      */
     if (lastKey) params.ExclusiveStartKey = lastKey;
 
-		const response = await documentClient.query(params).promise();
+    const response = await documentClient.query(params).promise();
 
-		if (response.LastEvaluatedKey) {
+    if (response.LastEvaluatedKey) {
       printLastEvalMessage(response.LastEvaluatedKey);
-		}
+    }
 
-		return response;
-	} catch (error) {
-		throw new Error(JSON.stringify(error, null, 2));
-	}
+    return response;
+  } catch (error) {
+    throw new Error(JSON.stringify(error, null, 2));
+  }
 };
 
 (async () => {
-	try {
-    console.log('---------------------Page 1---------------------');
-		const {
+  try {
+    console.log("---------------------Page 1---------------------");
+    const {
       Items: dataPage1,
-      LastEvaluatedKey: lastKeyPage1
+      LastEvaluatedKey: lastKeyPage1,
     } = await queryPaginatedData(2, null, true);
-    console.log('Query succeeded Page 1:', JSON.stringify(dataPage1.map(d => d.Subject), null, 2));
-    console.log('Last Evaluated Key Page 1:', lastKeyPage1);
+    console.log(
+      "Query succeeded Page 1:",
+      JSON.stringify(
+        dataPage1.map((d) => d.Subject),
+        null,
+        2
+      )
+    );
+    console.log("Last Evaluated Key Page 1:", lastKeyPage1);
 
     /**
      * The example contains 8 items in the table. If you query the data with a page size 2,
      * you'll need to continue querying the data
      */
-    console.log('---------------------Page 2---------------------');
+    console.log("---------------------Page 2---------------------");
     const {
       Items: dataPage2,
-      LastEvaluatedKey: lastKeyPage2
+      LastEvaluatedKey: lastKeyPage2,
     } = await queryPaginatedData(2, lastKeyPage1, true);
-    console.log('Query succeeded Page 2:', JSON.stringify(dataPage2.map(d => d.Subject), null, 2));
-    console.log('Last Evaluated Key Page 2:', lastKeyPage2);
+    console.log(
+      "Query succeeded Page 2:",
+      JSON.stringify(
+        dataPage2.map((d) => d.Subject),
+        null,
+        2
+      )
+    );
+    console.log("Last Evaluated Key Page 2:", lastKeyPage2);
 
     /**
      * Now let's scan backwards. Be aware that scanning backwards is not inclusive. It
      * will return all the possible data before the LastEvaluatedKey provided.
      */
-    console.log('---------------------Backwards-------------------');
+    console.log("---------------------Backwards-------------------");
     const {
       Items: dataPage3,
-      LastEvaluatedKey: lastKeyPage3
+      LastEvaluatedKey: lastKeyPage3,
     } = await queryPaginatedData(2, lastKeyPage2, false);
-    console.log('Query succeeded Page 1:', JSON.stringify(dataPage3.map(d => d.Subject), null, 2));
-    console.log('Last Evaluated Key Page 1:', lastKeyPage3);
-
-	} catch (error) {
-		console.error(error);
-	}
+    console.log(
+      "Query succeeded Page 1:",
+      JSON.stringify(
+        dataPage3.map((d) => d.Subject),
+        null,
+        2
+      )
+    );
+    console.log("Last Evaluated Key Page 1:", lastKeyPage3);
+  } catch (error) {
+    console.error(error);
+  }
 })();

--- a/node.js/WorkingWithQueries/query-with-pagination.js
+++ b/node.js/WorkingWithQueries/query-with-pagination.js
@@ -2,40 +2,40 @@
  * This example uses an extended version of the ProductCatalog data set
  * https://gist.github.com/jprivillaso/7063b5e082ed2f553b697d40c60c473e
  */
-const AWS = require('aws-sdk');
+const AWS = require("aws-sdk");
 
-AWS.config.update({ region: 'us-west-2' });
+AWS.config.update({ region: "us-west-2" });
 
 const documentClient = new AWS.DynamoDB.DocumentClient();
 
 const printLastEvalMessage = (lastEvaluatedKey) => {
-	const message = `
+  const message = `
     Not all items have been retrieved by this query.
     At least one another request is required to get all available items.
     The last evaluated key corresponds to:
     ${JSON.stringify(lastEvaluatedKey)}.
-  `.replace(/\s+/gm, ' ');
+  `.replace(/\s+/gm, " ");
 
   console.log(message);
-}
+};
 
 const queryPaginatedData = async (pageSize, lastKey) => {
-	try {
-		const params = {
-      TableName: 'Thread',
-      KeyConditionExpression: '#forumName = :forumName',
-			ExpressionAttributeNames: {
-				'#forumName': 'ForumName',
-			},
-			ExpressionAttributeValues: {
-				':forumName': "Amazon DynamoDB",
+  try {
+    const params = {
+      TableName: "Thread",
+      KeyConditionExpression: "#forumName = :forumName",
+      ExpressionAttributeNames: {
+        "#forumName": "ForumName",
+      },
+      ExpressionAttributeValues: {
+        ":forumName": "Amazon DynamoDB",
       },
       /**
        * This represents the amount of records per page. It's not needed, but we'll use it to simulate
        * the pagination
        */
       Limit: pageSize,
-      ScanIndexForward: true // Default value is true
+      ScanIndexForward: true, // Default value is true
     };
 
     /**
@@ -44,40 +44,40 @@ const queryPaginatedData = async (pageSize, lastKey) => {
      */
     if (lastKey) params.ExclusiveStartKey = lastKey;
 
-		const response = await documentClient.query(params).promise();
+    const response = await documentClient.query(params).promise();
 
-		if (response.LastEvaluatedKey) {
+    if (response.LastEvaluatedKey) {
       printLastEvalMessage(response.LastEvaluatedKey);
-		}
+    }
 
-		return response;
-	} catch (error) {
-		throw new Error(JSON.stringify(error, null, 2));
-	}
+    return response;
+  } catch (error) {
+    throw new Error(JSON.stringify(error, null, 2));
+  }
 };
 
 (async () => {
-	try {
-    console.log('---------------------Page 1---------------------');
-		const {
+  try {
+    console.log("---------------------Page 1---------------------");
+    const {
       Items: dataPage1,
-      LastEvaluatedKey: lastKeyPage1
+      LastEvaluatedKey: lastKeyPage1,
     } = await queryPaginatedData(2, null);
-    console.log('Query succeeded Page 1:', JSON.stringify(dataPage1, null, 2));
-    console.log('Last Evaluated Key Page 1:', lastKeyPage1);
+    console.log("Query succeeded Page 1:", JSON.stringify(dataPage1, null, 2));
+    console.log("Last Evaluated Key Page 1:", lastKeyPage1);
 
     /**
      * The example contains 8 items in the table. If you query the data with a page size 2,
      * you'll need to continue querying the data
      */
-    console.log('---------------------Page 2---------------------');
+    console.log("---------------------Page 2---------------------");
     const {
       Items: dataPage2,
-      LastEvaluatedKey: lastKeyPage2
+      LastEvaluatedKey: lastKeyPage2,
     } = await queryPaginatedData(2, lastKeyPage1);
-    console.log('Query succeeded Page 2:', JSON.stringify(dataPage2, null, 2));
-    console.log('Last Evaluated Key Page 2:', lastKeyPage2);
-	} catch (error) {
-		console.error(error);
-	}
+    console.log("Query succeeded Page 2:", JSON.stringify(dataPage2, null, 2));
+    console.log("Last Evaluated Key Page 2:", lastKeyPage2);
+  } catch (error) {
+    console.error(error);
+  }
 })();

--- a/node.js/WorkingWithQueries/query-with-pagination.js
+++ b/node.js/WorkingWithQueries/query-with-pagination.js
@@ -1,0 +1,83 @@
+/**
+ * This example uses an extended version of the ProductCatalog data set
+ * https://gist.github.com/jprivillaso/7063b5e082ed2f553b697d40c60c473e
+ */
+const AWS = require('aws-sdk');
+
+AWS.config.update({ region: 'us-west-2' });
+
+const documentClient = new AWS.DynamoDB.DocumentClient();
+
+const printLastEvalMessage = (lastEvaluatedKey) => {
+	const message = `
+    Not all items have been retrieved by this query.
+    At least one another request is required to get all available items.
+    The last evaluated key corresponds to:
+    ${JSON.stringify(lastEvaluatedKey)}.
+  `.replace(/\s+/gm, ' ');
+
+  console.log(message);
+}
+
+const queryPaginatedData = async (pageSize, lastKey) => {
+	try {
+		const params = {
+      TableName: 'Thread',
+      KeyConditionExpression: '#forumName = :forumName',
+			ExpressionAttributeNames: {
+				'#forumName': 'ForumName',
+			},
+			ExpressionAttributeValues: {
+				':forumName': "Amazon DynamoDB",
+      },
+      /**
+       * This represents the amount of records per page. It's not needed, but we'll use it to simulate
+       * the pagination
+       */
+      Limit: pageSize,
+      ScanIndexForward: true // Default value is true
+    };
+
+    /**
+     * The ExclusiveStartKey marks where the next page should start.
+     * DynamoDB will return ${pageSize} items beyond this point
+     */
+    if (lastKey) params.ExclusiveStartKey = lastKey;
+
+		const response = await documentClient.query(params).promise();
+
+		if (response.LastEvaluatedKey) {
+      printLastEvalMessage(response.LastEvaluatedKey);
+		}
+
+		return response;
+	} catch (error) {
+		throw new Error(JSON.stringify(error, null, 2));
+	}
+};
+
+(async () => {
+	try {
+    console.log('---------------------Page 1---------------------');
+		const {
+      Items: dataPage1,
+      LastEvaluatedKey: lastKeyPage1
+    } = await queryPaginatedData(2, null);
+    console.log('Query succeeded Page 1:', JSON.stringify(dataPage1, null, 2));
+    console.log('Last Evaluated Key Page 1:', lastKeyPage1);
+
+    /**
+     * The example contains 8 items in the table. If you query the data with a page size 2,
+     * you'll need to continue querying the data
+     */
+    console.log('---------------------Page 2---------------------');
+    const {
+      Items: dataPage2,
+      LastEvaluatedKey: lastKeyPage2
+    } = await queryPaginatedData(2, lastKeyPage1);
+    console.log('Query succeeded Page 2:', JSON.stringify(dataPage2, null, 2));
+    console.log('Last Evaluated Key Page 2:', lastKeyPage2);
+	} catch (error) {
+		console.error(error);
+	}
+})();


### PR DESCRIPTION
Created three files that exemplify the usage of pagination in DynamoDB

- A query including a page size
- A query using a page size that returns all the data from the Table
- A query using ScanningForward set to false

I used [this dataset](https://gist.github.com/jprivillaso/7063b5e082ed2f553b697d40c60c473e) for the exercise for the queries.